### PR TITLE
Append "d" if debug library (.dll/.lib) is built

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -46,6 +46,9 @@ else()
 	option(tensorflow_ENABLE_POSITION_INDEPENDENT_CODE "Enable PIE support" ON)
 endif()
 
+if(NOT CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX d)
+endif()
 
 if (NOT WIN32)
   # Threads: defines CMAKE_THREAD_LIBS_INIT and adds -pthread compile option


### PR DESCRIPTION
As found here https://stackoverflow.com/questions/27506415/set-cmake-target-name-for-debug-and-release-configuration it's possible to configure CMake so that "d" is appended to a compiled library.

E.G. building TensorFlow in Release will yield: tensorflow.dll - while in Debug: tensorflowd.dll